### PR TITLE
Add contentQueryIds to Graph API

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "bcrypt": "^2.0.0",
     "bluebird": "^3.5.1",
     "body-parser": "^1.18.2",
+    "cors": "^2.8.4",
     "deep-assign": "^2.0.0",
     "dotenv": "^5.0.1",
     "escape-string-regexp": "^1.0.5",

--- a/src/app.js
+++ b/src/app.js
@@ -1,15 +1,21 @@
 const express = require('express');
 const helmet = require('helmet');
+const cors = require('cors');
 const passport = require('passport');
+
 const authStrategies = require('./auth-strategies');
 const routes = require('./routes');
 
 passport.use(authStrategies.bearer);
 
 const app = express();
+const CORS = cors();
 
 app.use(passport.initialize());
 app.use(helmet());
+
+app.use(CORS);
+app.options('*', CORS);
 
 routes(app);
 

--- a/src/graph/definitions/content-query.graphql
+++ b/src/graph/definitions/content-query.graphql
@@ -2,6 +2,7 @@ type Query {
   allContentQueries(propertyId: String!, pagination: PaginationInput = {}, sort: ContentQuerySortInput = {}): ContentQueryConnection!
   contentQuery(input: ContentQueryInput!): ContentQuery!
   testContentQuery(input: ModelIdInput!): ContentQueryTest!
+  contentQueryIds(input: ModelIdInput!): [Int]
 }
 
 type Mutation {

--- a/src/graph/resolvers/content-query.js
+++ b/src/graph/resolvers/content-query.js
@@ -79,6 +79,12 @@ module.exports = {
       const { id } = input;
       return QueryRepo.test(id);
     },
+
+    contentQueryIds: async (root, { input }, { auth }) => {
+      auth.check();
+      const { id } = input;
+      return QueryRepo.contentIds(id);
+    },
   },
 
   /**

--- a/src/repos/query.js
+++ b/src/repos/query.js
@@ -43,6 +43,20 @@ module.exports = {
   },
 
   /**
+   * Returns all content IDs for the provided query.
+   *
+   * @param {string} queryId The content query ID.
+   */
+  async contentIds(queryId) {
+    const query = await this.findById(queryId);
+    const { key, baseVersion } = await PropertyRepo.findById(query.propertyId, {
+      key: 1,
+      baseVersion: 1,
+    });
+    return this.getContentIds(query, key, baseVersion);
+  },
+
+  /**
    * @param {object} params
    * @param {string} params.queryId
    * @param {Date} params.startDate

--- a/yarn.lock
+++ b/yarn.lock
@@ -736,6 +736,13 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cors@^2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.4.tgz#2bd381f2eb201020105cd50ea59da63090694686"
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 cross-spawn@^4:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
@@ -2941,7 +2948,7 @@ object-assign@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -4138,7 +4145,7 @@ validator@^9.4.1:
   version "9.4.1"
   resolved "https://registry.yarnpkg.com/validator/-/validator-9.4.1.tgz#abf466d398b561cd243050112c6ff1de6cc12663"
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 


### PR DESCRIPTION
Adds support for querying all content IDs that match a `ContentQuery`'s criteria, via the `contentQueryIds` graph query. This is accomplished by passing the `ContentQuery.id` to the graph query, which will return an array of integer, content IDs.

In addition, CORS was added to the root of the app.